### PR TITLE
Fix memory leak in parser, properly update num items property.

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -479,7 +479,7 @@ namespace slip {
       for(unsigned i = _replay.num_items; i <= id; ++i) {
         _replay.item[i].frame = new SlippiItemFrame[MAX_ITEM_LIFE];
       }
-      _replay.num_items = id;
+      _replay.num_items = id + 1;
     }
 
     if (f < MAX_ITEM_LIFE) {


### PR DESCRIPTION
Set `num_items` to `id + 1` instead of `id`, otherwise next time this item's frame array will get initialized again. 

This causes a memory leak and a crash after parsing multiple replays.