### PR TITLE
Fix function pointer types in conversion in picohash.h

### DIFF
--- a/src/picohash.h
+++ b/src/picohash.h
@@ -643,7 +643,7 @@ inline void picohash_init_md5(picohash_ctx_t *ctx)
     ctx->block_length = PICOHASH_MD5_BLOCK_LENGTH;
     ctx->digest_length = PICOHASH_MD5_DIGEST_LENGTH;
     ctx->_reset = (void (*)(void*))_picohash_md5_init;
-    ctx->_update = (void (*)(void*, const void*, long unsigned int))_picohash_md5_update;
+    ctx->_update = (void (*)(void*, const void*, size_t))_picohash_md5_update;
     ctx->_final = (void (*)(void*,void*))_picohash_md5_final;
 
     _picohash_md5_init(&ctx->_md5);
@@ -654,7 +654,7 @@ inline void picohash_init_sha1(picohash_ctx_t *ctx)
     ctx->block_length = PICOHASH_SHA1_BLOCK_LENGTH;
     ctx->digest_length = PICOHASH_SHA1_DIGEST_LENGTH;
     ctx->_reset = (void (*)(void*))_picohash_sha1_init;
-    ctx->_update = (void (*)(void*, const void*, long unsigned int))_picohash_sha1_update;
+    ctx->_update = (void (*)(void*, const void*, size_t))_picohash_sha1_update;
     ctx->_final = (void (*)(void*,void*))_picohash_sha1_final;
     _picohash_sha1_init(&ctx->_sha1);
 }
@@ -664,7 +664,7 @@ inline void picohash_init_sha224(picohash_ctx_t *ctx)
     ctx->block_length = PICOHASH_SHA224_BLOCK_LENGTH;
     ctx->digest_length = PICOHASH_SHA224_DIGEST_LENGTH;
     ctx->_reset = (void (*)(void*))_picohash_sha224_init;
-    ctx->_update = (void (*)(void*, const void*, long unsigned int))_picohash_sha256_update;
+    ctx->_update = (void (*)(void*, const void*, size_t))_picohash_sha256_update;
     ctx->_final = (void (*)(void*,void*))_picohash_sha224_final;
     _picohash_sha224_init(&ctx->_sha256);
 }
@@ -674,7 +674,7 @@ inline void picohash_init_sha256(picohash_ctx_t *ctx)
     ctx->block_length = PICOHASH_SHA256_BLOCK_LENGTH;
     ctx->digest_length = PICOHASH_SHA256_DIGEST_LENGTH;
     ctx->_reset = (void (*)(void*))_picohash_sha256_init;
-    ctx->_update = (void (*)(void*, const void*, long unsigned int))_picohash_sha256_update;
+    ctx->_update = (void (*)(void*, const void*, size_t))_picohash_sha256_update;
     ctx->_final = (void (*)(void*,void*))_picohash_sha256_final;
     _picohash_sha256_init(&ctx->_sha256);
 }


### PR DESCRIPTION
Otherwise build does not work with MinGW (incompatible conversion)