### PR TITLE
feat: Export Slippi 3.14 data to json

### DIFF
--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -81,6 +81,11 @@ std::string SlippiReplay::replayAsJson(bool delta) {
   if(MIN_VERSION(3,12,0)) {
     ss << JUIN(0,"language"      , s.language)       << ",\n";
   }
+  if(MIN_VERSION(3,14,0)) {
+    ss << JSTR(0,"match_id"          , s.match_id)          << ",\n";
+    ss << JUIN(0,"game_number"       , s.game_number)       << ",\n";
+    ss << JUIN(0,"tiebreaker_number" , s.tiebreaker_number) << ",\n";
+  }
   ss << JINT(0,"first_frame"   , s.first_frame)    << ",\n";
   ss << JINT(0,"last_frame"    , s.last_frame)     << ",\n";
   ss << JUIN(0,"sudden_death"  , s.sudden_death)   << ",\n";


### PR DESCRIPTION
In https://github.com/pcrain/slippc/commit/bf6fd6089cfce0c37ea583fca3c756b793a87758, the ability to parse out the new data like `match_id` was added. However, this data was never added to the json outputs anywhere, so if you ran `slippc -j` there was no way to read this data from external sources.

This PR adds this data to the JSON output so that it can be consumed.
For example, the new `match_id` is going to be very handy for splitting
between ranked and unranked replays.
