### PR TITLE
ci: Run tests and build on every PR and push

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+Dockerfile
+build/*
+build-win/*
+callgrind*
+slippc
+slippc-tests
+slippc.exe
+*.json
+*.gz
+*.slp
+_alt*
+Game*
+__*
+*~
+.todo
+test-replays/zlptest.zlp
+test-replays/zlptest.slp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/build-push-action@v4
+        with:
+          cache-from: type=gha
+          cache-to: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.4
+FROM ubuntu:22.04
+
+WORKDIR /slippc
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential=12.9ubuntu3 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN <<EOF
+mkdir -p /slippc/slippc/build
+make statictest
+./slippc-tests
+make static all
+EOF


### PR DESCRIPTION
I've written a minimal Dockerfile that can successfully run the tests
and build the slippc binary. By having the build itself done inside of a
Dockerfile, the build environment is portable to being runnable by
anyone who can run a docker container build.

At the same time, I've created a minimal GitHub Action workflow that
exercises said docker build so that every time there's a pull request or
a merge to the default branch, the tests will be run.
