### PR TITLE
buildInputs - not buildDepends

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@ in { stdenv ? pkgs.stdenv, xz ? pkgs.xz }:
 stdenv.mkDerivation {
   name = "slippc";
   src = ./.;
-  buildDepends = [ xz ];
+  buildInputs = [ xz ];
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
This wasn't building for me..`buildDepends` isn't a thing iirc. I don't know how my PR ever worked for me..but now it does rofl.

## Testing Done

`nix-build default.nix` succeeds and its `slippc` runs fine.