### PR TITLE
Fix: Calculate APM like slippi

### DIFF
--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -98,6 +98,7 @@ std::string Analysis::asJson() {
     ss << JUIN(1,"button_count",           ap[p].button_count)              << ",\n";
     ss << JUIN(1,"cstick_count",           ap[p].cstick_count)              << ",\n";
     ss << JUIN(1,"astick_count",           ap[p].astick_count)              << ",\n";
+    ss << JUIN(1,"trigger_count",          ap[p].trigger_count)             << ",\n";
     ss << JFLT(1,"actions_per_min",        ap[p].apm)                       << ",\n";
     ss << JUIN(1,"state_changes",          ap[p].state_changes)             << ",\n";
     ss << JFLT(1,"states_per_min",         ap[p].aspm)                      << ",\n";

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -116,9 +116,10 @@ struct AnalysisPlayer {
   unsigned     max_galint             =  0;  //Maximum GALINT frames after a ledgedash
   unsigned     button_count           =  0;  //Button presses
   unsigned     cstick_count           =  0;  //C stick movements
-  unsigned     astick_count           =  0;  //Action state changes
+  unsigned     astick_count           =  0;  //Analog stick movements
+  unsigned     trigger_count          =  0;  //Analog trigger movements
   float        apm                    =  0;  //Actions per minute (combines buttons and csticks)
-  unsigned     state_changes          =  0;  //Analog stick movements
+  unsigned     state_changes          =  0;  //Action state changes
   float        aspm                   =  0;  //Action states per minute
 
   unsigned     used_throws            =  0;  //Number of throws we threw out
@@ -169,6 +170,7 @@ struct Analysis {
   std::string     stage_name       = "";     //Readable name of the stage
   int             winner_port      = 0;      //Port index of the winning player (-1 == no winner)
   unsigned        game_length      = 0;      //Length of the game in frames (0 == internal frame -123)
+  unsigned        game_length_playable = 0;      //Length of the game only counting playable frames
   unsigned        timer            = 0;      //Game timer starting minutes
   AnalysisPlayer* ap;                        //Analysis of individual players in the game
   unsigned*       dynamics;                  //Interaction dynamics on a per-frame basis

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -99,10 +99,11 @@ namespace slip {
     }
     if (_replay.errors == 0) {
       DOUT1("  Successfully parsed replay!");
+      return true;
     } else {
       WARN("  Replay parsed with " << _replay.errors << " errors");
+      return false;
     }
-    return true;
   }
 
   bool Parser::_parseHeader() {


### PR DESCRIPTION
APM is calculated with the same formula as used by slippi-js and displayed in the official slippi launcher

* Formula used like here https://github.com/project-slippi/slippi-js/blob/master/src/common/stats/inputs.ts#L66
  * Counts analog stick moves differently and includes analog trigger moves
* Also includes a fix to report replay with errors as failed  parse